### PR TITLE
[fix] point browser entry point to dist/standalone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "engines": {
         "node": ">=11.0.0"
     },
-    "browser": "src/index.js",
+    "browser": "dist/standalone.js",
     "main": "src/index.js",
     "bin": "bin/har-to-k6.js",
     "dependencies": {


### PR DESCRIPTION
I recently changed the build process to build and include `standalone.js` when running `npm publish`, instead of doing that manually and commiting the built file to our repo.

I messed up with the `browser` entry point in package.json though, meaning that the package didn't point to the bundled file. This PR fixes that.