### PR TITLE
Release/v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-03-18
+
+### Added
+
+- `--add-sleep` flag for CLI
+- New export `normalizeHAR`
+
+### Fixed
+
+- Entries are sorted
+
 ## [0.8.0] - 2021-02-22
 
 ### Changed
@@ -116,7 +127,8 @@ Broken positional arg in caporal resulting in broken `har-to-k6` command.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/loadimpact/har-to-k6/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/loadimpact/har-to-k6/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/loadimpact/har-to-k6/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/loadimpact/har-to-k6/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/loadimpact/har-to-k6/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/loadimpact/har-to-k6/compare/v0.5.0...v0.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "har-to-k6",
     "description": "Convert LI-HAR to k6 script",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "license": "Apache-2.0",
     "keywords": [
         "k6",


### PR DESCRIPTION
## [0.9.0] - 2021-03-18

### Added

- `--add-sleep` flag for CLI
- New export `normalizeHAR`

### Fixed

- Entries are sorted