### PR TITLE
[fix] Multi variable support in check values.

### DIFF
--- a/src/codegen/index.js
+++ b/src/codegen/index.js
@@ -1,6 +1,6 @@
 const babel = require('prettier/parser-babel')
-const evaluateVariable = require('../render/evaluate')
 const expressions = require('../expression')
+const template = require('../render/template')
 
 const BUILD = Symbol('build')
 const UNQUOTED = Symbol('unquoted')
@@ -9,7 +9,6 @@ const hasOwnProperty = (obj, prop) =>
   Object.prototype.hasOwnProperty.call(obj, prop)
 
 const isVariable = (expr) => expressions.variable.test(expr)
-const getVariableName = (expr) => (expressions.variable.exec(expr) || [])[1]
 
 const makeTemplate = (build, render) => {
   render[BUILD] = build
@@ -64,7 +63,7 @@ const stringify = (ctx, expr, result) => {
     case 'number':
     case 'boolean':
       if (isVariable(expr)) {
-        return push(result, evaluateVariable(getVariableName(expr)))
+        return push(result, template(expr))
       }
 
       return push(result, JSON.stringify(expr))

--- a/src/codegen/index.js
+++ b/src/codegen/index.js
@@ -1,6 +1,7 @@
 const babel = require('prettier/parser-babel')
 const expressions = require('../expression')
 const template = require('../render/template')
+const evaluateVariable = require('../render/evaluate')
 
 const BUILD = Symbol('build')
 const UNQUOTED = Symbol('unquoted')
@@ -9,6 +10,13 @@ const hasOwnProperty = (obj, prop) =>
   Object.prototype.hasOwnProperty.call(obj, prop)
 
 const isVariable = (expr) => expressions.variable.test(expr)
+
+const getVariableName = (expr) => (expressions.variable.exec(expr) || [])[1]
+
+const isMultiVariableString = (expr) => {
+  const matches = [...expr.matchAll(expressions.variables)]
+  return matches.length > 1
+}
 
 const makeTemplate = (build, render) => {
   render[BUILD] = build
@@ -60,12 +68,19 @@ const stringify = (ctx, expr, result) => {
       return push(result, 'undefined')
 
     case 'string':
-    case 'number':
-    case 'boolean':
-      if (isVariable(expr)) {
+      if (isMultiVariableString(expr)) {
         return push(result, template(expr))
       }
 
+      // This will have to be single variable since the above case captures multi variable
+      if (isVariable(expr)) {
+        return push(result, evaluateVariable(getVariableName(expr)))
+      }
+
+      return push(result, JSON.stringify(expr))
+
+    case 'number':
+    case 'boolean':
       return push(result, JSON.stringify(expr))
 
     case 'function':

--- a/src/render/checks.js
+++ b/src/render/checks.js
@@ -1,10 +1,15 @@
 const check = require('./check')
-const object = require('./object')
+
+const objectProperty = (item) => [`"${item.name}"`, item.value].join(':')
 
 function checks(spec) {
   if (spec.size) {
-    const entries = [...spec].map(([name, item]) => check(name, item))
-    return `check(response, ${object(entries)});`
+    const items = [...spec].map(([name, item]) => check(name, item))
+    // Using dumb method of rendering the code here because we want to explicitly render ${varName}
+    // instead of resolving it.
+    const body = ['{', items.map(objectProperty), '}'].join('')
+
+    return `check(response, ${body});`
   } else {
     return null
   }

--- a/test/e2e/pass/multi-variable-checks.har
+++ b/test/e2e/pass/multi-variable-checks.har
@@ -1,0 +1,78 @@
+{
+  "log": {
+    "options": {
+      "stages": [
+        {
+          "duration": "1m",
+          "target": 20
+        },
+        {
+          "duration": "3m",
+          "target": 20
+        },
+        {
+          "duration": "1m",
+          "target": 0
+        }
+      ],
+      "ext": {
+        "loadimpact": {
+          "distribution": {
+            "amazon:us:ashburn": {
+              "loadZone": "amazon:us:ashburn",
+              "percent": 100
+            }
+          }
+        }
+      }
+    },
+    "pages": [],
+    "entries": [
+      {
+        "comment": "",
+        "checks": [],
+        "variables": [
+          {
+            "type": 0,
+            "name": "firstName",
+            "expression": "$.first_name"
+          },
+          {
+            "type": 0,
+            "name": "lastName",
+            "expression": "$.last_name"
+          }
+        ],
+        "request": {
+          "url": "http://test.k6.io/",
+          "method": "GET",
+          "queryString": [],
+          "headers": []
+        }
+      },
+      {
+        "comment": "",
+        "checks": [
+          {
+            "type": 1,
+            "expression": "$.full_name",
+            "condition": 2,
+            "value": "${firstName} ${lastName}"
+          }
+        ],
+        "variables": [],
+        "request": {
+          "url": "http://test.k6.io/",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "fullname",
+              "value": "${firstName}-${lastName}"
+            }
+          ],
+          "headers": []
+        }
+      }
+    ]
+  }
+}

--- a/test/e2e/pass/multi-variable-checks.js
+++ b/test/e2e/pass/multi-variable-checks.js
@@ -1,0 +1,48 @@
+import { sleep, check } from "k6";
+import http from "k6/http";
+
+import { URL } from "https://jslib.k6.io/url/1.0.0/index.js";
+import jsonpath from "https://jslib.k6.io/jsonpath/1.0.2/index.js";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 20 },
+    { duration: "3m", target: 20 },
+    { duration: "1m", target: 0 },
+  ],
+  ext: {
+    loadimpact: {
+      distribution: {
+        "amazon:us:ashburn": { loadZone: "amazon:us:ashburn", percent: 100 },
+      },
+    },
+  },
+};
+
+export default function main() {
+  let address, response;
+
+  const vars = {};
+
+  response = http.get("http://test.k6.io/");
+
+  vars["firstName"] = jsonpath.query(response.json(), "$.first_name")[0];
+
+  vars["lastName"] = jsonpath.query(response.json(), "$.last_name")[0];
+
+  address = new URL("http://test.k6.io/");
+  address.searchParams.append(
+    "fullname",
+    `${vars["firstName"]}-${vars["lastName"]}`
+  );
+  response = http.get(address.toString());
+  check(response, {
+    [`\$.full_name equals ${vars["firstName"]} ${vars["lastName"]}`]: response =>
+      jsonpath
+        .query(response.json(), "$.full_name")
+        .some(value => value === `${vars["firstName"]} ${vars["lastName"]}`),
+  });
+
+  // Automatically added sleep
+  sleep(1);
+}

--- a/test/e2e/pass/multi-variable-checks.js
+++ b/test/e2e/pass/multi-variable-checks.js
@@ -37,7 +37,7 @@ export default function main() {
   );
   response = http.get(address.toString());
   check(response, {
-    [`\$.full_name equals ${vars["firstName"]} ${vars["lastName"]}`]: response =>
+    "$.full_name equals ${firstName} ${lastName}": response =>
       jsonpath
         .query(response.json(), "$.full_name")
         .some(value => value === `${vars["firstName"]} ${vars["lastName"]}`),

--- a/test/e2e/pass/variables-checks.js
+++ b/test/e2e/pass/variables-checks.js
@@ -21,7 +21,7 @@ export default function main() {
     [`\$.token contains ${vars["token"]}`]: response =>
       jsonpath
         .query(response.json(), "$.token")
-        .some(values => values.includes(vars["token"])),
+        .some(values => values.includes(`${vars["token"]}`)),
     [`body matches /${vars["token"]}/`]: response => {
       const expr = new RegExp(`${vars["token"]}`);
       return expr.test(response.body);

--- a/test/e2e/pass/variables-checks.js
+++ b/test/e2e/pass/variables-checks.js
@@ -21,7 +21,7 @@ export default function main() {
     [`\$.token contains ${vars["token"]}`]: response =>
       jsonpath
         .query(response.json(), "$.token")
-        .some(values => values.includes(`${vars["token"]}`)),
+        .some(values => values.includes(vars["token"])),
     [`body matches /${vars["token"]}/`]: response => {
       const expr = new RegExp(`${vars["token"]}`);
       return expr.test(response.body);

--- a/test/e2e/pass/variables-checks.js
+++ b/test/e2e/pass/variables-checks.js
@@ -16,13 +16,13 @@ export default function main() {
 
   response = http.get("http://test.k6.io");
   check(response, {
-    [`status equals ${vars["token"]}`]: response =>
+    "status equals ${token}": response =>
       response.status.toString() === `${vars["token"]}`,
-    [`\$.token contains ${vars["token"]}`]: response =>
+    "$.token contains ${token}": response =>
       jsonpath
         .query(response.json(), "$.token")
         .some(values => values.includes(vars["token"])),
-    [`body matches /${vars["token"]}/`]: response => {
+    "body matches /${token}/": response => {
       const expr = new RegExp(`${vars["token"]}`);
       return expr.test(response.body);
     },


### PR DESCRIPTION
FIX check value referencing multiple variables only resolving first variable.

### HAR fragment / desired outcome / before PR result
```js
// HAR fragment
"entries": [
  {
    "variables": [
      {
        "type": JSONPath,
        "name": "firstName",
        "expression": "$.first_name"
      },
      {
        "type": JSONPath,
        "name": "lastName",
        "expression": "$.last_name"
      }
    ],
  },
  {
    "checks": [
      {
        "type": JSONPathValue,
        "expression": "$.full_name",
        "condition": equals,
        "value": "${firstName} ${lastName}"
      }
    ],
  }
]
    
// Desired outcome
check(response, {
  [`\$.full_name equals ${vars["firstName"]} ${vars["lastName"]}`]: response =>
    jsonpath
      .query(response.json(), "$.full_name")
      .some(value => value === `${vars["firstName"]} ${vars["lastName"]}`),
});    

// Before PR
check(response, {
  [`\$.full_name equals ${vars["firstName"]} ${vars["lastName"]}`]: response =>
    jsonpath
      .query(response.json(), "$.full_name")
      .some(value => value === vars["firstName"]),
});
```

**NOTE**: Only multi variable usage generate TemplateLiteral while single variable usage still generates MemberExpression.
```
Multi: `${vars["a"]} ${vars["b"]}`
Single: vars["a"]
```