### PR TITLE
[feat] Ability to specify group name without modifying id.

### DIFF
--- a/src/parse/page.js
+++ b/src/parse/page.js
@@ -1,13 +1,24 @@
 const sleep = require('./sleep')
 
-function page(node, result) {
+function pageName(node) {
   const nameParts = []
 
-  node.id && nameParts.push(node.id)
-  node.title && nameParts.push(node.title)
+  if (node.name) {
+    nameParts.push(node.name)
+  } else if (node.id) {
+    nameParts.push(node.id)
+  }
 
+  if (node.title) {
+    nameParts.push(node.title)
+  }
+
+  return nameParts.join(' - ')
+}
+
+function page(node, result) {
   const spec = {
-    name: nameParts.join(' - '),
+    name: pageName(node),
   }
 
   if (node.comment) {

--- a/src/validate/page.js
+++ b/src/validate/page.js
@@ -41,6 +41,12 @@ function validate(node, i, assay) {
       `Invalid page title (${i}): must be string`
     )
   }
+  if (!empty(node.name) && typeof node.name !== 'string') {
+    throw new InvalidArchiveError(
+      { name: 'InvalidPageName' },
+      `Invalid page name (${i}): must be string`
+    )
+  }
   if (node.sleep && !Array.isArray(node.sleep)) {
     throw new InvalidArchiveError(
       { name: 'InvalidPageSleep' },

--- a/test/unit/parse/page.test.js
+++ b/test/unit/parse/page.test.js
@@ -18,6 +18,54 @@ test('main', (t) => {
   )
 })
 
+test('favor name before title', (t) => {
+  const result = makeResult()
+  page({ id: 'page_id', name: 'Page name', title: 'Page title' }, result)
+  t.deepEqual(
+    result.pages,
+    new Map([
+      [
+        'page_id',
+        {
+          name: 'Page name - Page title',
+        },
+      ],
+    ])
+  )
+})
+
+test('fallback to using id as name', (t) => {
+  const result = makeResult()
+  page({ id: 'page_id_1', title: 'Page title' }, result)
+
+  const result2 = makeResult()
+  page({ id: 'page_id_2', name: '', title: 'Page title' }, result2)
+
+  t.deepEqual(
+    result.pages,
+    new Map([
+      [
+        'page_id_1',
+        {
+          name: 'page_id_1 - Page title',
+        },
+      ],
+    ])
+  )
+
+  t.deepEqual(
+    result2.pages,
+    new Map([
+      [
+        'page_id_2',
+        {
+          name: 'page_id_2 - Page title',
+        },
+      ],
+    ])
+  )
+})
+
 test('comment', (t) => {
   const result = makeResult()
   page({ id: 'page1', title: 'Page 1', comment: 'Heavy load' }, result)


### PR DESCRIPTION
HAR fragment (page with name property)
```js
// Input
{
  "id": "group_0_id",
  "title": "Title",
  "name": "Name"
}

// Output
group("Name - Title", function () {
  response = http.get("https://test.k6.io/");
});
```

HAR fragment (page without name property). Still generating same code as before this PR.
```js
// Input
{
  "id": "group_0_id",
  "title": "Title",
}

// Output
group("group_0_id - Title", function () {
  response = http.get("https://test.k6.io/");
});
```